### PR TITLE
Reproducing tcpnodelay regression

### DIFF
--- a/src/main/resources/jgroups-tcp.xml
+++ b/src/main/resources/jgroups-tcp.xml
@@ -18,6 +18,8 @@
          diag.enabled="true"
          diag.enable_tcp="true"
 
+         tcp_nodelay="true"
+
          thread_pool.enabled="${tp:true}"
          use_virtual_threads="${vthreads:false}"
 


### PR DESCRIPTION
I managed to reproduce it. The restore process in ISPN is a 100% write workload, without conflicting keys, and executed serially. I added a new option in the test (`P`) to populate the cache serially. Here are some numbers:

| # keys  | tcpnodelay | concurrency | time     |
|---------|------------|-------------|----------|
| 100_000 | `false`    | 50          | 4685 ms  |
| 100_000 | `true`     | 50          | 4575 ms  |
| 1_000   | `false`    | 1           | 18395 ms |
| 1_000   | `true`     | 1           | 1078 ms  |


Utilizing multiple threads to populate, the `tcpnodelay` doesn't seem to have any effect. However, we have quite a big change utilizing a single thread, going from ~18s to ~1s by enabling Nagle.


Perhaps it doesn't matter, but locally I had some other changes in the configuration files to create a cluster:

```diff
diff --git a/src/main/resources/control.xml b/src/main/resources/control.xml
index c3a0e61..b283fe4 100644
--- a/src/main/resources/control.xml
+++ b/src/main/resources/control.xml
@@ -10,7 +10,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:org:jgroups"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
-    <UDP bind_addr="match-interface:eth2,match-interface:eth0,match-interface:en0,site_local,loopback"
+    <UDP bind_addr="127.0.0.1"
          mcast_addr="${CONTROL_MCAST_ADDR:232.8.8.8}"
          mcast_port="${CONTROL_MCAST_PORT:55588}"
          ip_ttl="8"

```

And:

```diff
diff --git a/src/main/resources/jgroups-tcp.xml b/src/main/resources/jgroups-tcp.xml
index 332d222..fae6dba 100644
--- a/src/main/resources/jgroups-tcp.xml
+++ b/src/main/resources/jgroups-tcp.xml
@@ -10,7 +10,7 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xmlns="urn:org:jgroups"
         xsi:schemaLocation="urn:org:jgroups http://www.jgroups.org/schema/jgroups.xsd">
-    <TCP bind_addr="match-interface:eth2,match-interface:eth0,site_local,loopback"
+    <TCP bind_addr="127.0.0.1"
          bind_port="7800"
          recv_buf_size="20M"
          send_buf_size="10M"
```